### PR TITLE
Strawman for alternate hypertext cache pattern

### DIFF
--- a/draft-kelly-json-hal.txt
+++ b/draft-kelly-json-hal.txt
@@ -66,6 +66,7 @@ Table of Contents
    4.  Resource Objects  . . . . . . . . . . . . . . . . . . . . . .   4
      4.1.  Reserved Properties . . . . . . . . . . . . . . . . . . .   4
        4.1.1.  _links  . . . . . . . . . . . . . . . . . . . . . . .   4
+       4.1.3.  _transcluded  . . . . . . . . . . . . . . . . . . . .   4
        4.1.2.  _embedded . . . . . . . . . . . . . . . . . . . . . .   4
    5.  Link Objects  . . . . . . . . . . . . . . . . . . . . . . . .   4
      5.1.  href  . . . . . . . . . . . . . . . . . . . . . . . . . .   5
@@ -83,6 +84,7 @@ Table of Contents
      8.1.  Self Link . . . . . . . . . . . . . . . . . . . . . . . .   8
      8.2.  Link relations  . . . . . . . . . . . . . . . . . . . . .   8
      8.3.  Hypertext Cache Pattern . . . . . . . . . . . . . . . . .   9
+     8.4   Deprecation of "_embedded"  . . . . . . . . . . . . . . .  10
    9.  Security Considerations . . . . . . . . . . . . . . . . . . .  10
    10. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  10
    11. Normative References  . . . . . . . . . . . . . . . . . . . .  10
@@ -134,6 +136,9 @@ Internet-Draft     JSON Hypertext Application Language          May 2016
    "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
    document are to be interpreted as described in [RFC2119].
 
+   Features marked as "DEPRECATED" are necessary for backwards compatibility but
+   new uses of them MUST be avoided.
+
 3.  HAL Documents
 
    A HAL Document uses the format described in [RFC4627] and has the
@@ -179,11 +184,13 @@ Internet-Draft     JSON Hypertext Application Language          May 2016
 
    A Resource Object represents a resource.
 
-   It has two reserved properties:
+   It has three reserved properties:
 
    (1)  "_links": contains links to other resources.
 
-   (2)  "_embedded": contains embedded resources.
+   (2)  "_transcluded": contains transcluded representations of other resources.
+
+   (2)  "_embedded": contains embedded resources. This property is deprecated but still supported for backwards compatibility.
 
    All other properties MUST be valid JSON, and represent the current
    state of the resource.
@@ -199,9 +206,20 @@ Internet-Draft     JSON Hypertext Application Language          May 2016
    of Link Objects.  The subject resource of these links is the Resource
    Object of which the containing "_links" object is a property.
 
-4.1.2.  _embedded
+4.1.2.  _transcluded
 
-   The reserved "_embedded" property is OPTIONAL
+   The reserved "_transcluded" property is OPTIONAL
+
+   It is an object whose property names are URIs [RFC3986] and values are
+   a Resource Object.
+
+   Trancluded Resources MAY be a full, partial, or inconsistent version of
+   the representation served from the target URI. All Transcluded Resources
+   SHOULD have at least one entry Link Object targeting them.
+
+4.1.3.  _embedded
+
+   The reserved "_embedded" property is DEPRECATED and OPTIONAL
 
    It is an object whose property names are link relation types (as
    defined by [RFC5988]) and values are either a Resource Object or an
@@ -356,8 +374,8 @@ Internet-Draft     JSON Hypertext Application Language          May 2016
        "next": { "href": "/orders?page=2" },
        "find": { "href": "/orders{?id}", "templated": true }
      },
-     "_embedded": {
-       "orders": [{
+     "_transcluded": {
+       "/orders/123": {
            "_links": {
              "self": { "href": "/orders/123" },
              "basket": { "href": "/baskets/98712" },
@@ -366,7 +384,8 @@ Internet-Draft     JSON Hypertext Application Language          May 2016
            "total": 30.00,
            "currency": "USD",
            "status": "shipped",
-         },{
+         },
+         "/orders/124": {
            "_links": {
              "self": { "href": "/orders/124" },
              "basket": { "href": "/baskets/97213" },
@@ -375,7 +394,7 @@ Internet-Draft     JSON Hypertext Application Language          May 2016
            "total": 20.00,
            "currency": "USD",
            "status": "processing"
-       }]
+         }
      },
      "currentlyProcessing": 14,
      "shippedToday": 20
@@ -386,7 +405,7 @@ Internet-Draft     JSON Hypertext Application Language          May 2016
    which can be expanded with an 'id' variable to go directly to a specific
    order.
 
-   In order to reduce the number of network requests needed it also embeds
+   In order to reduce the number of network requests needed it also transcluded
    representations of the related "order" resource.  Each of these has its own
    links to the associated "basket" and "customer" resources, and properties
    showing their "total", "currency" and "status".
@@ -459,22 +478,22 @@ Internet-Draft     JSON Hypertext Application Language          May 2016
 
 8.3.  Hypertext Cache Pattern
 
-   The "hypertext cache pattern" allows servers to use embedded
+   The "hypertext cache pattern" allows servers to transclude related
    resources to dynamically reduce the number of requests a client
    makes, improving the efficiency and performance of the application.
 
-   Clients MAY be automated for this purpose so that, for any given link
-   relation, they will read from an embedded resource (if present) in
-   preference to traversing a link.
+   Clients MAY be automated for this purpose so that they will read the target
+   of that link from the "_transcluded" section (if present) in preference to
+   making a network request to follow link.
 
-   To activate this client behaviour for a given link, servers SHOULD
-   add an embedded resource into the representation with the same
-   relation.
+   To activate this client behaviour for a given link, servers SHOULD add a
+   transcluded resource into the representation keyed on the link's target URI.
 
    Servers SHOULD include a link even when the related resource is embedded
    because client support for this technique is OPTIONAL. Servers SHOULD NOT
    remove an embedded resource because clients may be dependent on its
-   existence.
+   existence. Client SHOULD NOT fail due to the absence of a transcluded
+   resource for any link because server support for this feature is OPTIONAL.
 
    The following examples shows the hypertext cache pattern applied to
    an "author" link:
@@ -496,8 +515,8 @@ Internet-Draft     JSON Hypertext Application Language          May 2016
        "self": { "href": "/blog-post" },
        "author": { "href": "/people/alan-watts" }
      },
-     "_embedded": {
-       "author": {
+     "_transcluded": {
+       "/people/alan-watts": {
          "_links": { "self": { "href": "/people/alan-watts" } },
          "name": "Alan Watts",
          "born": "January 6, 1915",
@@ -506,7 +525,15 @@ Internet-Draft     JSON Hypertext Application Language          May 2016
      }
    }
 
+8.4  Deprecation of "_embedded"
 
+   New uses of the deprecated "_embedded" section should be avoided and existing
+   uses should be removed where and when possible. Servers SHOULD NOT remove
+   embedded resources because this might break clients. Clients SHOULD cease
+   and desist using embedded resources even when they are included by servers.
+
+   Both clients and servers SHOULD use transcluded resources to implement the
+   hypertext cache pattern.
 
 
 Kelly                   Expires November 12, 2016               [Page 9]

--- a/draft-kelly-json-hal.txt
+++ b/draft-kelly-json-hal.txt
@@ -208,12 +208,15 @@ Internet-Draft     JSON Hypertext Application Language          May 2016
    array of Resource Objects.
 
    Embedded Resources MAY be a full, partial, or inconsistent version of
-   the representation served from the target URI.
+   the representation served from the target URI. All Embedded Resources
+   SHOULD have an equivalent Link Object.
 
 5.  Link Objects
 
-   A Link Object represents a hyperlink from the containing resource to
-   a URI.  It has the following properties:
+   A Link Object represents a hyperlink from the containing resource to a URI.
+   All relationships of interest to clients should be represented by a Link
+   Object, including any that are also represented by an Embedded Object. It has
+   the following properties:
 
 
 
@@ -348,6 +351,8 @@ Internet-Draft     JSON Hypertext Application Language          May 2016
    {
      "_links": {
        "self": { "href": "/orders" },
+       "orders": [ { "href": "/orders/123" },
+                   { "href": "/orders/124" } ],
        "next": { "href": "/orders?page=2" },
        "find": { "href": "/orders{?id}", "templated": true }
      },
@@ -376,13 +381,15 @@ Internet-Draft     JSON Hypertext Application Language          May 2016
      "shippedToday": 20
    }
 
-   Here, the order list document provides a "next" link directing to the
-   next page, and a "find" link containing a URI Template which can be
-   expanded with an 'id' variable to go directly to a specific order.
+   Here, the order list document provides links to several "orders", a "next"
+   link directing to the next page, and a "find" link containing a URI Template
+   which can be expanded with an 'id' variable to go directly to a specific
+   order.
 
-   It also has two embedded resources, "orders".  Each of these has its
-   own links to the associated "basket" and "customer" resources, and
-   properties showing their "total", "currency" and "status".
+   In order to reduce the number of network requests needed it also embeds
+   representations of the related "order" resource.  Each of these has its own
+   links to the associated "basket" and "customer" resources, and properties
+   showing their "total", "currency" and "status".
 
    Additionally, the order list resource has its own properties
    "currentlyProcessing" and "shippedToday".
@@ -464,9 +471,10 @@ Internet-Draft     JSON Hypertext Application Language          May 2016
    add an embedded resource into the representation with the same
    relation.
 
-   Servers SHOULD NOT entirely "swap out" a link for an embedded
-   resource (or vice versa) because client support for this technique is
-   OPTIONAL.
+   Servers SHOULD include a link even when the related resource is embedded
+   because client support for this technique is OPTIONAL. Servers SHOULD NOT
+   remove an embedded resource because clients may be dependent on its
+   existence.
 
    The following examples shows the hypertext cache pattern applied to
    an "author" link:


### PR DESCRIPTION
This is a strawman change to to spec to support URI, rather than relationship, keyed transclusion.

It has 3 main advantages. (a) it allows transcluded representations to be reused and cached, (b) it eliminates several edge cases in which consumer behavior is undefined and (c) it improves the evolvability of HAL based APIs.

Using the URI of transcluded resources allows consumers to cache those representations. That cache could be used to process other representations (in addition to the current one). It would also allow efficient transclusion of resources related in multiple ways. (For exmaple, if the requester and owner of a "change request" were the same user.)

This approach eliminates situations where a particular relationship is declared in both the _links and _embedded sections. It is unclear from the spec how, or even if, consumers should merge those sets of related resources. This scenario is particularly challenging if the embedded representaions lack selfs or the links and embeddeds don't match.

Finally, and most importantly in my view, this approach improves the evolvability of HAL APIs. The current approach requires us to guess, at design time, which relationships are (a) going to be most used and (b) can be performantly embedded. Then we have to commit to those guesses in perpetuity before we have even seen our API in real use. The `_embedded` approach forces us to engage in premature optimization. By making all relationships `_links` and then providing a separate, optional, optimization path we can design for clarity and delay optimization until we have actual usage and performance data. It also allows us to re-optimization as usage and performance patterns change.