### PR TITLE
Resource Objects MUST have self link

### DIFF
--- a/draft-kelly-json-hal.txt
+++ b/draft-kelly-json-hal.txt
@@ -408,7 +408,7 @@ Internet-Draft     JSON Hypertext Application Language          May 2016
 
 8.1.  Self Link
 
-   Each Resource Object SHOULD contain a 'self' link that corresponds
+   Each Resource Object MUST contain a 'self' link that corresponds
    with the IANA registered 'self' relation (as defined by [RFC5988])
    whose target is the resource's URI.
 

--- a/draft-kelly-json-hal.xml
+++ b/draft-kelly-json-hal.xml
@@ -233,7 +233,7 @@ Content-Type: application/hal+json
 
     <section anchor="recommendations" title="Recommendations">
       <section anchor="self-link" title="Self Link">
-        <t>Each Resource Object SHOULD contain a 'self' link that corresponds with the IANA registered 'self' relation (as defined by <xref target="RFC5988"/>) whose target is the resource's URI.</t>
+        <t>Each Resource Object MUST contain a 'self' link that corresponds with the IANA registered 'self' relation (as defined by <xref target="RFC5988"/>) whose target is the resource's URI.</t>
       </section>
 
       <section anchor="link-relations" title="Link relations">


### PR DESCRIPTION
When working with an API, it is always good to tell the API about itself. This is why I am suggesting a change to section 8.1 using the word MUST instead of SHOULD for supplying a self link.