### PR TITLE
Adding an optional attribute "seen" to the Link object

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,6 @@ Wonk-mode:
 
 The txt is actually generated from the xml so it's better if you edit the latter.
 You also get extra brownie points if you:
-* install xml2rfc (`pip install xml2rfc`)
+* install xml2rfc (`pip install xml2rfc`) or use https://xml2rfc.tools.ietf.org/
 * generate the txt from the xml
 * submit both in your PR

--- a/draft-kelly-json-hal.txt
+++ b/draft-kelly-json-hal.txt
@@ -308,7 +308,7 @@ Internet-Draft     JSON Hypertext Application Language          May 2016
    The "seen" property is OPTIONAL.
 
    Its value is a string intended for stating the last observation time 
-   of the target resource (as defined by [RFC5988]).
+   of the target resource (as defined by [RFC3339]).
 
 6.  Example Document
 

--- a/draft-kelly-json-hal.txt
+++ b/draft-kelly-json-hal.txt
@@ -1,7 +1,5 @@
 
 
-
-
 Network Working Group                                           M. Kelly
 Internet-Draft                                                 Stateless
 Intended status: Informational                              May 11, 2016
@@ -76,6 +74,7 @@ Table of Contents
      5.6.  profile . . . . . . . . . . . . . . . . . . . . . . . . .   6
      5.7.  title . . . . . . . . . . . . . . . . . . . . . . . . . .   6
      5.8.  hreflang  . . . . . . . . . . . . . . . . . . . . . . . .   6
+     5.9.  seen  . . . . . . . . . . . . . . . . . . . . . . . . . .   6
    6.  Example Document  . . . . . . . . . . . . . . . . . . . . . .   6
    7.  Media Type Parameters . . . . . . . . . . . . . . . . . . . .   8
      7.1.  profile . . . . . . . . . . . . . . . . . . . . . . . . .   8
@@ -86,7 +85,7 @@ Table of Contents
    9.  Security Considerations . . . . . . . . . . . . . . . . . . .  10
    10. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  10
    11. Normative References  . . . . . . . . . . . . . . . . . . . .  10
-   Appendix A.  Acknowledgements . . . . . . . . . . . . . . . . . .  10
+   Appendix A.  Acknowledgements . . . . . . . . . . . . . . . . . .  11
    Appendix B.  Frequently Asked Questions . . . . . . . . . . . . .  11
      B.1.  How should a client know the
            meaning/structure/semantics/type of a resource? . . . . .  11
@@ -105,7 +104,6 @@ Table of Contents
    The JSON Hypertext Application Language (HAL) is a standard which
    establishes conventions for expressing hypermedia controls, such as
    links, with JSON [RFC4627].
-
 
 
 
@@ -307,19 +305,12 @@ Internet-Draft     JSON Hypertext Application Language          May 2016
 
    The "seen" property is OPTIONAL.
 
-   Its value is a string intended for stating the last observation time 
+   Its value is a string intended for stating the last observation time
    of the target resource (as defined by [RFC3339]).
 
 6.  Example Document
 
    The following is an example document representing a list of orders
-
-
-
-
-
-
-
 
 
 
@@ -526,40 +517,40 @@ Internet-Draft     JSON Hypertext Application Language          May 2016
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119,
               DOI 10.17487/RFC2119, March 1997,
-              <http://www.rfc-editor.org/info/rfc2119>.
+              <https://www.rfc-editor.org/info/rfc2119>.
+
+   [RFC3339]  Klyne, G. and C. Newman, "Date and Time on the Internet:
+              Timestamps", RFC 3339, DOI 10.17487/RFC3339, July 2002,
+              <https://www.rfc-editor.org/info/rfc3339>.
 
    [RFC3986]  Berners-Lee, T., Fielding, R., and L. Masinter, "Uniform
               Resource Identifier (URI): Generic Syntax", STD 66,
               RFC 3986, DOI 10.17487/RFC3986, January 2005,
-              <http://www.rfc-editor.org/info/rfc3986>.
+              <https://www.rfc-editor.org/info/rfc3986>.
 
    [RFC4627]  Crockford, D., "The application/json Media Type for
               JavaScript Object Notation (JSON)", RFC 4627,
               DOI 10.17487/RFC4627, July 2006,
-              <http://www.rfc-editor.org/info/rfc4627>.
+              <https://www.rfc-editor.org/info/rfc4627>.
 
    [RFC5988]  Nottingham, M., "Web Linking", RFC 5988,
               DOI 10.17487/RFC5988, October 2010,
-              <http://www.rfc-editor.org/info/rfc5988>.
+              <https://www.rfc-editor.org/info/rfc5988>.
 
    [RFC6570]  Gregorio, J., Fielding, R., Hadley, M., Nottingham, M.,
               and D. Orchard, "URI Template", RFC 6570,
               DOI 10.17487/RFC6570, March 2012,
-              <http://www.rfc-editor.org/info/rfc6570>.
+              <https://www.rfc-editor.org/info/rfc6570>.
 
    [RFC6906]  Wilde, E., "The 'profile' Link Relation Type", RFC 6906,
               DOI 10.17487/RFC6906, March 2013,
-              <http://www.rfc-editor.org/info/rfc6906>.
+              <https://www.rfc-editor.org/info/rfc6906>.
 
    [W3C.NOTE-curie-20101216]
               Birbeck, M. and S. McCarron, "CURIE Syntax 1.0", World
               Wide Web Consortium NOTE NOTE-curie-20101216, December
               2010, <http://www.w3.org/TR/2010/NOTE-curie-20101216>.
 
-Appendix A.  Acknowledgements
-
-   Thanks to Darrel Miller, Mike Amundsen, and everyone in hal-discuss
-   for their suggestions and feedback.
 
 
 
@@ -568,6 +559,11 @@ Kelly                   Expires November 12, 2016              [Page 10]
 
 Internet-Draft     JSON Hypertext Application Language          May 2016
 
+
+Appendix A.  Acknowledgements
+
+   Thanks to Darrel Miller, Mike Amundsen, and everyone in hal-discuss
+   for their suggestions and feedback.
 
    The author takes all responsibility for errors and omissions.
 
@@ -615,11 +611,6 @@ B.5.  Why does HAL have no forms?
 
 
 
-
-
-
-
-
 Kelly                   Expires November 12, 2016              [Page 11]
 
 Internet-Draft     JSON Hypertext Application Language          May 2016
@@ -661,19 +652,3 @@ Author's Address
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Kelly                   Expires November 12, 2016              [Page 12]

--- a/draft-kelly-json-hal.txt
+++ b/draft-kelly-json-hal.txt
@@ -303,6 +303,13 @@ Internet-Draft     JSON Hypertext Application Language          May 2016
    Its value is a string and is intended for indicating the language of
    the target resource (as defined by [RFC5988]).
 
+5.9.  seen
+
+   The "seen" property is OPTIONAL.
+
+   Its value is a string intended for stating the last observation time 
+   of the target resource (as defined by [RFC5988]).
+
 6.  Example Document
 
    The following is an example document representing a list of orders

--- a/draft-kelly-json-hal.xml
+++ b/draft-kelly-json-hal.xml
@@ -177,7 +177,7 @@ Content-Type: application/hal+json
 
       <section anchor="link-seen" title="seen">
         <t>The "seen" property is OPTIONAL.</t>
-        <t>Its value is a string intended for stating the last observation time of the target resource (as defined by <xref target="RFC5988"/>).</t>
+        <t>Its value is a string intended for stating the last observation time of the target resource (as defined by <xref target="RFC3339"/>).</t>
       </section>
     </section>
 

--- a/draft-kelly-json-hal.xml
+++ b/draft-kelly-json-hal.xml
@@ -2,6 +2,7 @@
 
 <!DOCTYPE rfc SYSTEM "http://xml.resource.org/authoring/rfc2629.dtd" [
 <!ENTITY rfc2119 SYSTEM 'http://xml.resource.org/public/rfc/bibxml/reference.RFC.2119.xml'>
+<!ENTITY rfc3339 SYSTEM 'http://xml.resource.org/public/rfc/bibxml/reference.RFC.3339.xml'>
 <!ENTITY rfc3986 SYSTEM 'http://xml.resource.org/public/rfc/bibxml/reference.RFC.3986.xml'>
 <!ENTITY rfc4627 SYSTEM 'http://xml.resource.org/public/rfc/bibxml/reference.RFC.4627.xml'>
 <!ENTITY rfc5988 SYSTEM 'http://xml.resource.org/public/rfc/bibxml/reference.RFC.5988.xml'>
@@ -322,6 +323,7 @@ Content-Type: application/hal+json
   <back>
     <references title="Normative References">
       &rfc2119;
+      &rfc3339;
       &rfc3986;
       &rfc4627;
       &rfc5988;

--- a/draft-kelly-json-hal.xml
+++ b/draft-kelly-json-hal.xml
@@ -174,6 +174,11 @@ Content-Type: application/hal+json
         <t>The "hreflang" property is OPTIONAL.</t>
         <t>Its value is a string and is intended for indicating the language of the target resource (as defined by <xref target="RFC5988"/>).</t>
       </section>
+
+      <section anchor="link-seen" title="seen">
+        <t>The "seen" property is OPTIONAL.</t>
+        <t>Its value is a string intended for stating the last observation time of the target resource (as defined by <xref target="RFC5988"/>).</t>
+      </section>
     </section>
 
     <section anchor="example" title="Example Document">


### PR DESCRIPTION
Resources with link collections originating from other resources has currently no way of telling the resource consumers (clients) how old the link collection is, which means the only way a consumer can find out if it has the most recent collection of links is by requesting these links. This generates potential unnecessary requests. Including the optional attribute "seen" in the Link object allows the resource to set the time for its most recent observation for a given link and that informs the client about its age. 

### Purpose
If consumers are very keen on having a fairly recent collection of links the "seen" the consumers can decide for themselves whether the additional request is necessary or not. The "seen" timestamp informs about the age of each part of the collection and when a given link was last observed, and thus the age of the collection can be determined. 

### Why
Why is it necessary to include an extra attribute for that -  why not just use the caching information in the response headers? I believe the semantics are different - caching headers are for the complete response as such and thus for the response object state validity and does not necessarily deal with the Link or Link collections validity. The latter are actually references to external resources and thus not necessarily authoritatively owned by the resource. 

### Example
An example could be an account resource, or a customer resource. The account resource might have two or more collections of Links 1: the transactions belonging to the account and 2: payment cards belonging to the account. A customer may have a Link collection of accounts.

A response from the `accounts/{accountId}` resource includes say `_links` and possibly `_embedded` objects as part of the response. The caching headers will deal with the validity of the information of the `account object` which in the case it includes a balance is dependent on the transactions and thus `transaction`Link objects are tied closely to the `account` object and in this case the actual resource and these links could use the response headers.
The transactions are naturally immutable objects, which means the information from "seen" informs the client about the last time the  balance was updated, looking at the `card` Links however, they are not tied to the account in the same direct way although very important.

A response from the `customers/{custId}` resource includes a Link collection of `accounts` the caching settings for the customer object imho would not have to be constrained to the maximum time from an account has been changed, removed or created for that customer, that is a decision the consuming client can make as it knows the context and can make the extra request if necessary, everyone else can used the customer object if the "seen" timestamps for the account links are good enough for their concrete context. The benefit is that the customer resource do not have to update its Links collections for customers frequently, because customer is not authoritative on accounts (the accounts resource is!) and even though it is important in some contexts to know what accounts are available for a customer and thus be able to discover changes to that fast - other contexts may be much more relaxed on this issue.

### Tooling
My hope is that the explanation here and the  addition to the spec is found useful, we have already made an tool available that supports the "seen" attribute in Link. It can be found under [jackson-dataformat-hal](https://github.com/openapi-tools/jackson-dataformat-hal) - [more specifically](https://github.com/openapi-tools/jackson-dataformat-hal/blob/master/src/main/java/io/openapitools/jackson/dataformat/hal/HALLink.java#L31)
 
Thank you very much
