### PR TITLE
Define CURIEs as documentation attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,5 @@ Wonk-mode:
 The txt is actually generated from the xml so it's better if you edit the latter.
 You also get extra brownie points if you:
 * install xml2rfc (`pip install xml2rfc`)
-* generate the txt from the xml
+* generate the txt from the xml (`xml2rfc draft-kelly-json-hal.xml --text`)
 * submit both in your PR

--- a/draft-kelly-json-hal.txt
+++ b/draft-kelly-json-hal.txt
@@ -82,19 +82,20 @@ Table of Contents
    8.  Recommendations . . . . . . . . . . . . . . . . . . . . . . .   8
      8.1.  Self Link . . . . . . . . . . . . . . . . . . . . . . . .   8
      8.2.  Link relations  . . . . . . . . . . . . . . . . . . . . .   8
+       8.2.1.  CURIEs  . . . . . . . . . . . . . . . . . . . . . . .   8
      8.3.  Hypertext Cache Pattern . . . . . . . . . . . . . . . . .   9
    9.  Security Considerations . . . . . . . . . . . . . . . . . . .  10
    10. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  10
    11. Normative References  . . . . . . . . . . . . . . . . . . . .  10
-   Appendix A.  Acknowledgements . . . . . . . . . . . . . . . . . .  10
+   Appendix A.  Acknowledgements . . . . . . . . . . . . . . . . . .  11
    Appendix B.  Frequently Asked Questions . . . . . . . . . . . . .  11
      B.1.  How should a client know the
            meaning/structure/semantics/type of a resource? . . . . .  11
      B.2.  Where can I find libraries for working with HAL?  . . . .  11
      B.3.  Why are the reserved properties prefixed with an
            underscore? . . . . . . . . . . . . . . . . . . . . . . .  11
-     B.4.  Are all underscore-prefixed properties reserved?  . . . .  11
-     B.5.  Why does HAL have no forms? . . . . . . . . . . . . . . .  11
+     B.4.  Are all underscore-prefixed properties reserved?  . . . .  12
+     B.5.  Why does HAL have no forms? . . . . . . . . . . . . . . .  12
    Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  12
 
 1.  Introduction
@@ -105,7 +106,6 @@ Table of Contents
    The JSON Hypertext Application Language (HAL) is a standard which
    establishes conventions for expressing hypermedia controls, such as
    links, with JSON [RFC4627].
-
 
 
 
@@ -420,26 +420,26 @@ Internet-Draft     JSON Hypertext Application Language          May 2016
    meaning and/or behaviour of the target Resource.  This will improve
    the discoverability of the API.
 
-   The CURIE Syntax [W3C.NOTE-curie-20101216] MAY be used for brevity
-   for these URIs.  CURIEs are established within a HAL document via a
-   set of Link Objects with the relation type "curies" on the root
+8.2.1.  CURIEs
+
+   Private-use scheme names (as defined by [RFC7595]) MAY be used.
+   Generally, this is done for brevity of these URIs.  To support
+   providing documentation for these "compact" URIs, private-use schemes
+   MAY be annotated with a CURIE; a Documentation URI that when
+   dereferenced in a web browser provide relevant documentation.
+   Documentation URIs MUST NOT be used as a link relation for the target
+   Resource it attributes.  CURIEs are established within a HAL document
+   via a set of Link Objects with the relation type "curies" on the root
    Resource Object.  These links contain a URI Template with the token
    'rel', and are named via the "name" property.
 
-   {
-     "_links": {
-       "self": { "href": "/orders" },
-       "curies": [{
-         "name": "acme",
-         "href": "http://docs.acme.com/relations/{rel}",
-         "templated": true
-       }],
-       "acme:widgets": { "href": "/widgets" }
-     }
-   }
 
-   The above demonstrates the relation "http://docs.acme.com/relations/
-   widgets" being abbreviated to "acme:widgets" via CURIE syntax.
+
+
+
+
+
+
 
 
 
@@ -449,6 +449,22 @@ Kelly                   Expires November 12, 2016               [Page 8]
 
 Internet-Draft     JSON Hypertext Application Language          May 2016
 
+
+   {
+     "_links": {
+       "self": { "href": "/orders" },
+       "curies": [{
+         "name": "com.acme",
+         "href": "http://docs.acme.com/relations/{rel}",
+         "templated": true
+       }],
+       "com.acme:widgets": { "href": "/widgets" }
+     }
+   }
+
+   The above demonstrates the use of a private-use scheme in the
+   relation "com.acme:widget", as well as providing Documentation URI
+   "http://docs.acme.com/relations/widgets" via a CURIE attribute.
 
 8.3.  Hypertext Cache Pattern
 
@@ -481,6 +497,15 @@ Internet-Draft     JSON Hypertext Application Language          May 2016
    }
 
 
+
+
+
+
+Kelly                   Expires November 12, 2016               [Page 9]
+
+Internet-Draft     JSON Hypertext Application Language          May 2016
+
+
    After:
 
    {
@@ -499,13 +524,6 @@ Internet-Draft     JSON Hypertext Application Language          May 2016
    }
 
 
-
-
-Kelly                   Expires November 12, 2016               [Page 9]
-
-Internet-Draft     JSON Hypertext Application Language          May 2016
-
-
 9.  Security Considerations
 
    TBD
@@ -519,40 +537,22 @@ Internet-Draft     JSON Hypertext Application Language          May 2016
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119,
               DOI 10.17487/RFC2119, March 1997,
-              <http://www.rfc-editor.org/info/rfc2119>.
+              <https://www.rfc-editor.org/info/rfc2119>.
 
    [RFC3986]  Berners-Lee, T., Fielding, R., and L. Masinter, "Uniform
               Resource Identifier (URI): Generic Syntax", STD 66,
               RFC 3986, DOI 10.17487/RFC3986, January 2005,
-              <http://www.rfc-editor.org/info/rfc3986>.
+              <https://www.rfc-editor.org/info/rfc3986>.
 
    [RFC4627]  Crockford, D., "The application/json Media Type for
               JavaScript Object Notation (JSON)", RFC 4627,
               DOI 10.17487/RFC4627, July 2006,
-              <http://www.rfc-editor.org/info/rfc4627>.
+              <https://www.rfc-editor.org/info/rfc4627>.
 
    [RFC5988]  Nottingham, M., "Web Linking", RFC 5988,
               DOI 10.17487/RFC5988, October 2010,
-              <http://www.rfc-editor.org/info/rfc5988>.
+              <https://www.rfc-editor.org/info/rfc5988>.
 
-   [RFC6570]  Gregorio, J., Fielding, R., Hadley, M., Nottingham, M.,
-              and D. Orchard, "URI Template", RFC 6570,
-              DOI 10.17487/RFC6570, March 2012,
-              <http://www.rfc-editor.org/info/rfc6570>.
-
-   [RFC6906]  Wilde, E., "The 'profile' Link Relation Type", RFC 6906,
-              DOI 10.17487/RFC6906, March 2013,
-              <http://www.rfc-editor.org/info/rfc6906>.
-
-   [W3C.NOTE-curie-20101216]
-              Birbeck, M. and S. McCarron, "CURIE Syntax 1.0", World
-              Wide Web Consortium NOTE NOTE-curie-20101216, December
-              2010, <http://www.w3.org/TR/2010/NOTE-curie-20101216>.
-
-Appendix A.  Acknowledgements
-
-   Thanks to Darrel Miller, Mike Amundsen, and everyone in hal-discuss
-   for their suggestions and feedback.
 
 
 
@@ -561,6 +561,25 @@ Kelly                   Expires November 12, 2016              [Page 10]
 
 Internet-Draft     JSON Hypertext Application Language          May 2016
 
+
+   [RFC6570]  Gregorio, J., Fielding, R., Hadley, M., Nottingham, M.,
+              and D. Orchard, "URI Template", RFC 6570,
+              DOI 10.17487/RFC6570, March 2012,
+              <https://www.rfc-editor.org/info/rfc6570>.
+
+   [RFC6906]  Wilde, E., "The 'profile' Link Relation Type", RFC 6906,
+              DOI 10.17487/RFC6906, March 2013,
+              <https://www.rfc-editor.org/info/rfc6906>.
+
+   [RFC7595]  Thaler, D., Ed., Hansen, T., and T. Hardie, "Guidelines
+              and Registration Procedures for URI Schemes", BCP 35,
+              RFC 7595, DOI 10.17487/RFC7595, June 2015,
+              <https://www.rfc-editor.org/info/rfc7595>.
+
+Appendix A.  Acknowledgements
+
+   Thanks to Darrel Miller, Mike Amundsen, and everyone in hal-discuss
+   for their suggestions and feedback.
 
    The author takes all responsibility for errors and omissions.
 
@@ -590,6 +609,15 @@ B.3.  Why are the reserved properties prefixed with an underscore?
    properties that represent the resource's state, and underscore was
    the character picked.
 
+
+
+
+
+Kelly                   Expires November 12, 2016              [Page 11]
+
+Internet-Draft     JSON Hypertext Application Language          May 2016
+
+
    Another reason for prefixing the reserved properties is to make it
    visually apparent that the reserved properties are distinct from
    standard properties belonging to the resource.
@@ -606,18 +634,6 @@ B.5.  Why does HAL have no forms?
    capabilities.  An additional media type is planned for the future
    which will add form-like controls on top of HAL.
 
-
-
-
-
-
-
-
-Kelly                   Expires November 12, 2016              [Page 11]
-
-Internet-Draft     JSON Hypertext Application Language          May 2016
-
-
 Author's Address
 
    Mike Kelly
@@ -625,22 +641,6 @@ Author's Address
 
    Email: mike@stateless.co
    URI:   http://stateless.co/
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 

--- a/draft-kelly-json-hal.xml
+++ b/draft-kelly-json-hal.xml
@@ -7,7 +7,7 @@
 <!ENTITY rfc5988 SYSTEM 'http://xml.resource.org/public/rfc/bibxml/reference.RFC.5988.xml'>
 <!ENTITY rfc6570 SYSTEM 'http://xml.resource.org/public/rfc/bibxml/reference.RFC.6570.xml'>
 <!ENTITY rfc6906 SYSTEM 'http://xml.resource.org/public/rfc/bibxml/reference.RFC.6906.xml'>
-<!ENTITY NOTE-curie SYSTEM 'http://xml.resource.org/public/rfc/bibxml4/reference.W3C.NOTE-curie-20101216.xml'>
+<!ENTITY rfc7595 SYSTEM 'http://xml.resource.org/public/rfc/bibxml/reference.RFC.7595.xml'>
 ]>
 
 <?xml-stylesheet type='text/xsl' href='rfc2629.xslt' ?>
@@ -238,24 +238,26 @@ Content-Type: application/hal+json
 
       <section anchor="link-relations" title="Link relations">
         <t>Custom link relation types (Extension Relation Types in <xref target="RFC5988"/>) SHOULD be URIs that when dereferenced in a web browser provide relevant documentation, in the form of an HTML page, about the meaning and/or behaviour of the target Resource. This will improve the discoverability of the API.</t>
-        <t>The CURIE Syntax <xref target="W3C.NOTE-curie-20101216" /> MAY be used for brevity for these URIs. CURIEs are established within a HAL document via a set of Link Objects with the relation type "curies" on the root Resource Object. These links contain a URI Template with the token 'rel', and are named via the "name" property.</t>
+
+        <section anchor="curies" title="CURIEs">  
+          <t>Private-use scheme names (as defined by <xref target="RFC7595" />) MAY be used. Generally, this is done for brevity of these URIs. To support providing documentation for these "compact" URIs, private-use schemes MAY be annotated with a CURIE; a Documentation URI that when dereferenced in a web browser provide relevant documentation. Documentation URIs MUST NOT be used as a link relation for the target Resource it attributes. CURIEs are established within a HAL document via a set of Link Objects with the relation type "curies" on the root Resource Object. These links contain a URI Template with the token 'rel', and are named via the "name" property.</t>
 
 <figure><artwork><![CDATA[
 {
   "_links": {
     "self": { "href": "/orders" },
     "curies": [{
-      "name": "acme",
+      "name": "com.acme",
       "href": "http://docs.acme.com/relations/{rel}",
       "templated": true
     }],
-    "acme:widgets": { "href": "/widgets" }
+    "com.acme:widgets": { "href": "/widgets" }
   }
 }
 ]]></artwork></figure>
 
-        <t>The above demonstrates the relation "http://docs.acme.com/relations/widgets" being abbreviated to "acme:widgets" via CURIE syntax.</t>
-
+          <t>The above demonstrates the use of a private-use scheme in the relation "com.acme:widget", as well as providing Documentation URI "http://docs.acme.com/relations/widgets" via a CURIE attribute.</t>
+        </section>
       </section>
 
       <section anchor="hypertext-cache-pattern" title="Hypertext Cache Pattern">
@@ -322,7 +324,7 @@ Content-Type: application/hal+json
       &rfc5988;
       &rfc6570;
       &rfc6906;
-      &NOTE-curie;
+      &rfc7595;
     </references>
 
     <!--<references title="Informative References">-->


### PR DESCRIPTION
This change introduces the concept of private-use scheme prefixes
generaly used to shorten link relation names.

Additionally, CURIEs are now well-defined as a mechanism for
linking documentation for private-use schemes. It also makes clear
these Documentation URLs must not be used as link relations.